### PR TITLE
Fix `develop` command not found bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Rebilly Spinup
+# Rebilly Spinup
 
 Monorepository encompassing all packages relevant to the Spinup Framework.
 

--- a/packages/spinup-cli/lib/commands/create.js
+++ b/packages/spinup-cli/lib/commands/create.js
@@ -5,7 +5,6 @@ const Tasks = require('@hjvedvik/tasks');
 const sortPackageJson = require('sort-package-json');
 const {hasYarn, exec} = require('../utils');
 
-// TODO consider global yarn install
 module.exports = async (name, template = 'default') => {
     const dir = absolutePath(name);
     const projectName = path.basename(dir);

--- a/packages/spinup-cli/lib/utils/index.js
+++ b/packages/spinup-cli/lib/utils/index.js
@@ -14,6 +14,7 @@ exports.exec = function exec(cmd, args = [], options = {}, context = process.cwd
     return execa(cmd, args, {
         stdio: options.stdio || 'ignore',
         cwd: context,
+        shell: options.shell || false,
     });
 };
 

--- a/packages/spinup-cli/package.json
+++ b/packages/spinup-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rebilly/spinup-cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Rebilly Spinup CLI for generating websites based on Rebilly's templates",
   "main": "bin/rebilly-spinup.js",
   "license": "MIT",


### PR DESCRIPTION
Fixes a bug where the `develop` command could not be spawned correctly. Now explicitly uses the local `shell` to trigger the wrapped command.